### PR TITLE
Expose testingWriter using a new TestingWriter API.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -134,7 +134,7 @@ func newNode(t *testing.T, i int) *node {
 	addr := strconv.Itoa(i)
 	_, transport := raft.NewInmemTransport(raft.ServerAddress(addr))
 
-	out := &testingWriter{t}
+	out := TestingWriter(t)
 	config := raft.DefaultConfig()
 	config.LocalID = raft.ServerID(addr)
 	config.Logger = log.New(out, fmt.Sprintf("%s: ", addr), 0)

--- a/log.go
+++ b/log.go
@@ -1,6 +1,15 @@
 package rafttest
 
-import "testing"
+import (
+	"io"
+	"testing"
+)
+
+// TestingWriter returns an io.Writer that forwards the stream it receives to
+// the Logf function of the given testing instance.
+func TestingWriter(t *testing.T) io.Writer {
+	return &testingWriter{t: t}
+}
 
 // Implement io.Writer and forward what it receives to a
 // t.Testing logger.


### PR DESCRIPTION
Useful when consuming code needs to be able to set the logger of a
test raft instance not created directly with rafttest.