### PR TITLE
Don't use Term.When().Command() to schedule disconnections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - golint
   - deadcode
   - project=github.com/CanonicalLtd/raft-test
-  - GO_RAFT_TEST_LATENCY=2.0 $GOPATH/bin/overalls -project $project -covermode=count -- -timeout 60s
+  - GO_RAFT_TEST_LATENCY=5.0 $GOPATH/bin/overalls -project $project -covermode=count -- -timeout 120s
   - $GOPATH/bin/goveralls -coverprofile overalls.coverprofile -service=travis-ci
 
 go:

--- a/control_test.go
+++ b/control_test.go
@@ -210,14 +210,18 @@ func TestControl_RestoreAfterDisconnection(t *testing.T) {
 	defer control.Close()
 
 	term := control.Elect("0")
-	term.When().Command(1).Committed().Disconnect("1")
 	term.When().Command(4).Committed().Snapshot()
-	term.When().Command(5).Committed().Reconnect("1")
 
 	r := rafts["0"]
 	for i := 0; i < 6; i++ {
 		err := r.Apply([]byte{}, time.Second).Error()
 		require.NoError(t, err)
+		if i == 0 {
+			term.Disconnect("1")
+		}
+		if i == 4 {
+			term.Reconnect("1")
+		}
 	}
 
 	control.Barrier()

--- a/internal/election/tracker.go
+++ b/internal/election/tracker.go
@@ -57,6 +57,14 @@ func NewTracker(logger *log.Logger) *Tracker {
 	}
 }
 
+// Ignore stops propagating leadership change notifications, which will be
+// simply dropped on the floor. Should be called before the final Close().
+func (t *Tracker) Ignore() {
+	for _, observer := range t.observers {
+		observer.Ignore()
+	}
+}
+
 // Close stops watching for leadership changes in the cluster.
 func (t *Tracker) Close() {
 	for _, observer := range t.observers {


### PR DESCRIPTION
That turned out to be problematic because leadership can be lost and re-acquired
when disconnecting and then reconnecting a follower.

Instead, there are now explicit Term.Disconnect() and Term.Reconnect() APIs that
account for leadership glitches.